### PR TITLE
Layout user/#45

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -30,3 +30,8 @@
  body {
    font-family: 'Sawarabi Mincho', sans-serif;
  }
+
+ .post-image{
+   overflow: hidden; // 要素のボックスからはみ出した部分を隠す
+   cursor: pointer; // マウスカーソルを手の形にする
+ }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -38,3 +38,26 @@
    align-items: center;
    justify-content: center;
  }
+
+
+
+.link {
+
+color:#C0C0C0;
+text-decoration: none;
+
+}
+
+.link:hover {
+
+color:#000;
+text-decoration:none;
+
+}
+
+.link:active {
+
+color:#999;
+text-decoration:none;
+
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -24,6 +24,9 @@
  }
 
  .heading {
-  font-family: "Hannari";
-  font-size: 32px; /* フォントサイズを、32pxに設定 */
-}
+   font-size: 32px;
+ }
+
+ body {
+   font-family: 'Sawarabi Mincho', sans-serif;
+ }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -34,4 +34,7 @@
  .post-image{
    overflow: hidden; // 要素のボックスからはみ出した部分を隠す
    cursor: pointer; // マウスカーソルを手の形にする
+   display: flex;
+   align-items: center;
+   justify-content: center;
  }

--- a/app/assets/stylesheets/homes.scss
+++ b/app/assets/stylesheets/homes.scss
@@ -5,7 +5,6 @@
 .top {
   width: 100%;
   height: 550px;
-  font-family: "Hannari";
   text-align: center;
   background-image: image-url("top_image.jpg");
   background-size: cover;
@@ -37,9 +36,6 @@
   padding-top: 10px;
 }
 
-.about {
-  font-family: "Hannari";
-}
 .about-h1{
   background: linear-gradient(transparent 50%, #ff9999 0%);
 }

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -13,7 +13,7 @@
       <%= f.password_field :password, autocomplete: "off", class: "form-control" %>
     </div>
 
-    <div class="form-group">
+    <div class="actions">
       <%= f.submit t('.sign_in'), class: "btn btn-primary btn-block" %>
     </div>
     <% end %>

--- a/app/views/homes/top.html.erb
+++ b/app/views/homes/top.html.erb
@@ -5,7 +5,7 @@
         じもたび
       </h1>
       <p class="top-theme">
-        ~地元を旅して、魅力を再発見！~
+        〜地元を旅して、魅力を再発見！〜
       </p>
       <div class="guest-sign">
         <%= link_to ' お試しログインはこちら', users_guest_sign_in_path, method: :post, class: 'btn btn-light fas fa-sign-in-alt btn-lg' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,14 +7,14 @@
 
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
-    <link href="https://fonts.googleapis.com/earlyaccess/hannari.css" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Sawarabi+Mincho&display=swap" rel="stylesheet">
   </head>
 
   <body>
     <%= render 'layouts/header' %>
-    <div class="main">
+    <main>
       <%= yield %>
-    </div>
+    </main>
     <%= render 'layouts/footer' %>
   </body>
 </html>

--- a/app/views/users/_info.html.erb
+++ b/app/views/users/_info.html.erb
@@ -1,5 +1,5 @@
 <div class="row">
-  <div class="col-md-12 m-1">
+  <div class="col-md-12 mt-3">
     <p class="text-center">
       <%= attachment_image_tag user, :profile_image, :fill, 100, 100, format: 'jpeg', fallback: "no_image_user.jpg", class: "rounded-circle" %>
     </p>

--- a/app/views/users/_info.html.erb
+++ b/app/views/users/_info.html.erb
@@ -1,14 +1,11 @@
 <table class="table">
-  <h3 class="font-weight-bold">ユーザー情報</h3>
   <tr>
     <%= attachment_image_tag user, :profile_image, :fill, 100, 100, format: 'jpeg', fallback: "no_image_user.jpg" %>
   </tr>
   <tr>
-    <th>ユーザー名</th>
     <th><%= user.name %></th>
   </tr>
   <tr>
-    <th>自己紹介</th>
     <th><%= user.introduction %></th>
   </tr>
 </table>

--- a/app/views/users/_info.html.erb
+++ b/app/views/users/_info.html.erb
@@ -1,15 +1,16 @@
-<table class="table">
-  <tr>
-    <%= attachment_image_tag user, :profile_image, :fill, 100, 100, format: 'jpeg', fallback: "no_image_user.jpg" %>
-  </tr>
-  <tr>
-    <th><%= user.name %></th>
-  </tr>
-  <tr>
-    <th><%= user.introduction %></th>
-  </tr>
-</table>
-
+<div class="row">
+  <div class="col-md-12 m-1">
+    <p class="text-center">
+      <%= attachment_image_tag user, :profile_image, :fill, 100, 100, format: 'jpeg', fallback: "no_image_user.jpg", class: "rounded-circle" %>
+    </p>
+  </div>
+  <div class="col-md-12 m-1">
+    <h4 class="font-weight-bold text-center"><%= user.name %></h4>
+  </div>
+  <div class="col-md-12 m-1">
+    <p><%= user.introduction %></p>
+  </div>
+</div>
 <div class="row">
   <% if user.id == current_user.id %>
     <%= link_to " プロフィール編集", edit_user_path(user),class: "btn btn-outline-secondary btn-block fas fa-user-cog edit_user_#{user.id}" %>

--- a/app/views/users/_info.html.erb
+++ b/app/views/users/_info.html.erb
@@ -1,0 +1,20 @@
+<table class="table">
+  <h3 class="font-weight-bold">ユーザー情報</h3>
+  <tr>
+    <%= attachment_image_tag user, :profile_image, :fill, 100, 100, format: 'jpeg', fallback: "no_image_user.jpg" %>
+  </tr>
+  <tr>
+    <th>ユーザー名</th>
+    <th><%= user.name %></th>
+  </tr>
+  <tr>
+    <th>自己紹介</th>
+    <th><%= user.introduction %></th>
+  </tr>
+</table>
+
+<div class="row">
+  <% if user.id == current_user.id %>
+    <%= link_to " プロフィール編集", edit_user_path(user),class: "btn btn-outline-secondary btn-block fas fa-user-cog edit_user_#{user.id}" %>
+  <% end %>
+</div>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -23,23 +23,6 @@
     <div class="actions">
       <%= f.submit "変更を保存", class: "btn btn-success btn-block" %>
     </div>
-
-    <hr class="border-dark">
-
-    <div>
-      <%= link_to '戻る', :back, class:"btn btn-link btn-block" %>
-    </div>
   </div>
 </div>
-
-
-
-
-
-
-
-
-
-
-
 <% end %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,13 +1,45 @@
-<h2>プロフィール編集</h2>
-<%= form_with model: @user, local:true do |f| %>
-  <%= render 'layouts/errors', obj: @user %>
-  <%= f.label :ユーザー名 %>
-  <%= f.text_field :name, placeholder:"ユーザー名"%>
-  <%= attachment_image_tag @user, :profile_image, :fill, 60, 60, fallback: "no_image.jpg"%>
-  <%= f.label :プロフィール画像 %>
-  <%= f.attachment_field :profile_image, placeholder: "プロフィール画像" %>
-  <%= f.label :自己紹介 %>
-  <%= f.text_area :introduction, placeholder: "自己紹介を入力してください" %>
+<div class="card col-sm-6 mx-auto my-5">
+  <div class="card-body">
+    <h2 class="mt-1 mb-3 font-weight-bold">プロフィール編集</h2>
+    <%= form_with model: @user, local:true do |f| %>
+    <%= render 'layouts/errors', obj: @user %>
 
-  <%= f.submit "変更を保存" %>
+    <div class="form-group">
+      <%= f.label :name, class: "form-label" %>
+      <%= f.text_field :name, placeholder:"ユーザー名", class: "form-control" %>
+    </div>
+
+    <div class="form-group">
+      <%= f.label :profile_image %><br>
+      <%= attachment_image_tag @user, :profile_image, :fill, 60, 60, fallback: "no_image.jpg"%>
+      <%= f.attachment_field :profile_image, placeholder: "プロフィール画像" %>
+    </div>
+
+    <div class="form-group">
+      <%= f.label :introduction, class: "form-label" %>
+      <%= f.text_area :introduction, placeholder: "自己紹介を入力してください", class: "form-control" %>
+    </div>
+
+    <div class="actions">
+      <%= f.submit "変更を保存", class: "btn btn-success btn-block" %>
+    </div>
+
+    <hr class="border-dark">
+
+    <div>
+      <%= link_to '戻る', :back, class:"btn btn-link btn-block" %>
+    </div>
+  </div>
+</div>
+
+
+
+
+
+
+
+
+
+
+
 <% end %>

--- a/app/views/users/like.html.erb
+++ b/app/views/users/like.html.erb
@@ -1,48 +1,73 @@
-<div class="container px-5 px-sm-0">
+<div class="container my-4">
   <div class="row">
     <div class="col-md-3">
-      <h3 class="font-weight-bold">ユーザー情報</h3>
       <%= render 'info', user: current_user %>
     </div>
     <div class="col-md-8 offset-md-1">
-      <table class="table table-hover table-inverse">
-        <thead>
-          <tr>
-            <th><%= link_to '投稿一覧', user_path %></th>
-            <th><%= link_to "お気に入り投稿一覧", like_user_path(@user) %></th>
-            <% if @likes.length != 0 %>
-              <% @likes.each do |post| %>
-                <div class="card mb-3" style="max-width: 500px;">
-                  <td><%= link_to post_path(post.id) do %>
-                    <%= attachment_image_tag post, :image, :fill, 200, 150, format: 'jpeg', fallback: "no_image.jpg" %>
-                    <% end %>
-                  </td>
+      <div class="row border-bottom">
+        <div class="col-md text-center">
+          <h4 class="mt-3"><%= link_to '投稿一覧', user_path %></h4>
+        </div>
+        <div class="col-md  text-center">
+          <h4 class="mt-3">お気に入り投稿一覧</h4>
+        </div>
+      </div>
 
-                  <td><%= post.title %></td>
-
-                  <td><%= post.caption %></td>
-
-                  <!-- post.spot.address -->
-                  <!-- 投稿に関連づけられた所在地を表示 -->
-
-                  <!-- post.tag.tag_name -->
-                  <!-- 投稿に関連づけられたタグを表示 -->
-
-                  <td><%= post.created_at.strftime('%Y年%-m月%-d日')%></td>
-                  <td><%= link_to user_path(post.user) do %>
-                    <%= post.user.name %>
-                    <% end %>
-                  </td>
-                </tr>
-              <% end %>
-            <% else %>
-              <tr>
-                <td>お気に入りはまだ保存されていません</td>
-              </tr>
-            <% end %>
-          </tr>
-        </thead>
-      </table>
+      <% if @likes.length != 0 %>
+        <% @likes.each do |post| %>
+        <div class="card my-3 p-3">
+          <div class="row no-gutters">
+            <div class="col-md-4 my-auto">
+              <div class="post-image">
+                <%= link_to post_path(post.id) do %>
+                  <%= attachment_image_tag post, :image, width: "100%", height:"auto", format: "jpeg", fallback: "no_image.jpg" %>
+                <% end %>
+              </div>
+            </div>
+            <div class="col-md-8 my-auto">
+              <div class="card-body col-md">
+                <div class="row">
+                  <div class="col-sm-12">
+                    <h4 class="card-title font-weight-bold">
+                      <%= link_to post_path(post.id) do %>
+                        <%= post.title %>
+                      <% end %>
+                    </h4>
+                  </div>
+                  <div class="col-sm-12">
+                    <p class="card-text"><%= post.caption.truncate(24) %></p>
+                  </div>
+                  <div class="col-sm-4">
+                    <p class="card-text"><!-- post.spot.address --></p>
+                    <!-- 投稿に関連づけられた所在地を表示 -->
+                  </div>
+                  <div class="col-sm-8">
+                    <p class="card-text"><!-- post.tag.tag_name --></p>
+                    <!-- 投稿に関連づけられたタグを表示 -->
+                  </div>
+                  <div class="col-sm-8">
+                    <p>
+                      <%= post.created_at.strftime('%Y年%-m月%-d日')%>
+                      &nbsp|&nbsp
+                      <%= link_to user_path(post.user) do %>
+                      <%= post.user.name %>
+                      <% end %>
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <% end %>
+      <% else %>
+        <div class="card my-5 p-3">
+          <div class="text-center">
+            お気に入りはまだ保存されていません
+          </div>
+        </div>
+      <% end %>
+      <!-- paginate @like -->
     </div>
   </div>
 </div>

--- a/app/views/users/like.html.erb
+++ b/app/views/users/like.html.erb
@@ -1,12 +1,4 @@
-<div class="profile-container">
-  <%= attachment_image_tag @user, :profile_image, :fill, 100, 100, format: 'jpeg', fallback: "no_image_user.jpg" %>
-  <h3 class="profile-name"><%= @user.name %></h3>
-  <%= @user.introduction %>
-
-  <% if @user.id == current_user.id %>
-    <p><%= link_to "プロフィール編集", edit_user_path(@user) %></p>
-  <% end %>
-</div>
+<%= render 'info', user: current_user %>
 
 <h2><%= link_to '投稿一覧', user_path %></h2>
 <h2><%= link_to "お気に入り投稿一覧", like_user_path(@user) %></h2>

--- a/app/views/users/like.html.erb
+++ b/app/views/users/like.html.erb
@@ -4,11 +4,11 @@
       <%= render 'info', user: current_user %>
     </div>
     <div class="col-md-8 offset-md-1">
-      <div class="row border-bottom">
+      <div class="row">
         <div class="col-md text-center">
-          <h4 class="mt-3"><%= link_to '投稿一覧', user_path %></h4>
+          <h4 class="mt-3"><%= link_to '投稿一覧', user_path, class: "link" %></h4>
         </div>
-        <div class="col-md  text-center">
+        <div class="col-md text-center">
           <h4 class="mt-3">お気に入り投稿一覧</h4>
         </div>
       </div>

--- a/app/views/users/like.html.erb
+++ b/app/views/users/like.html.erb
@@ -12,7 +12,7 @@
             <th><%= link_to "お気に入り投稿一覧", like_user_path(@user) %></th>
             <% if @likes.length != 0 %>
               <% @likes.each do |post| %>
-                <tr class="card mb-3" style="max-width: 540px;">
+                <div class="card mb-3" style="max-width: 500px;">
                   <td><%= link_to post_path(post.id) do %>
                     <%= attachment_image_tag post, :image, :fill, 200, 150, format: 'jpeg', fallback: "no_image.jpg" %>
                     <% end %>

--- a/app/views/users/like.html.erb
+++ b/app/views/users/like.html.erb
@@ -1,33 +1,48 @@
-<%= render 'info', user: current_user %>
-
-<h2><%= link_to '投稿一覧', user_path %></h2>
-<h2><%= link_to "お気に入り投稿一覧", like_user_path(@user) %></h2>
-<% if @likes.length != 0 %>
-  <% @likes.each do |post| %>
-    <div>
-      <p><%= link_to post_path(post.id) do %>
-        <%= attachment_image_tag post, :image, :fill, 200, 150, format: 'jpeg', fallback: "no_image.jpg" %>
-        <%= post.title %>
-        <% end %>
-      </p>
-
-      <p><%= post.caption %></p>
-
-      <!-- post.spot.address -->
-      <!-- 投稿に関連づけられた所在地を表示 -->
-
-      <!-- post.tag.tag_name -->
-      <!-- 投稿に関連づけられたタグを表示 -->
-
-      <p>
-        <%= post.created_at.strftime('%Y年%-m月%-d日')%>
-        &nbsp|&nbsp
-        <%= link_to user_path(post.user) do %>
-        <%= post.user.name %>
-        <% end %>
-      </p>
+<div class="container px-5 px-sm-0">
+  <div class="row">
+    <div class="col-md-3">
+      <h3 class="font-weight-bold">ユーザー情報</h3>
+      <%= render 'info', user: current_user %>
     </div>
-  <% end %>
-<% else %>
-  お気に入りはまだ登録されていません
-<% end %>
+    <div class="col-md-8 offset-md-1">
+      <table class="table table-hover table-inverse">
+        <thead>
+          <tr>
+            <th><%= link_to '投稿一覧', user_path %></th>
+            <th><%= link_to "お気に入り投稿一覧", like_user_path(@user) %></th>
+            <% if @likes.length != 0 %>
+              <% @likes.each do |post| %>
+                <tr class="card mb-3" style="max-width: 540px;">
+                  <td><%= link_to post_path(post.id) do %>
+                    <%= attachment_image_tag post, :image, :fill, 200, 150, format: 'jpeg', fallback: "no_image.jpg" %>
+                    <% end %>
+                  </td>
+
+                  <td><%= post.title %></td>
+
+                  <td><%= post.caption %></td>
+
+                  <!-- post.spot.address -->
+                  <!-- 投稿に関連づけられた所在地を表示 -->
+
+                  <!-- post.tag.tag_name -->
+                  <!-- 投稿に関連づけられたタグを表示 -->
+
+                  <td><%= post.created_at.strftime('%Y年%-m月%-d日')%></td>
+                  <td><%= link_to user_path(post.user) do %>
+                    <%= post.user.name %>
+                    <% end %>
+                  </td>
+                </tr>
+              <% end %>
+            <% else %>
+              <tr>
+                <td>お気に入りはまだ保存されていません</td>
+              </tr>
+            <% end %>
+          </tr>
+        </thead>
+      </table>
+    </div>
+  </div>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,12 +1,4 @@
-<div class="profile-container">
-  <%= attachment_image_tag @user, :profile_image, :fill, 100, 100, format: 'jpeg', fallback: "no_image_user.jpg" %>
-  <h3 class="profile-name"><%= @user.name %></h3>
-  <%= @user.introduction %>
-
-  <% if @user.id == current_user.id %>
-    <p><%= link_to "プロフィール編集", edit_user_path(@user) %></p>
-  <% end %>
-</div>
+<%= render 'info', user: current_user %>
 
 <h2><%= link_to '投稿一覧', user_path %></h2>
 <h2><%= link_to "お気に入り投稿一覧", like_user_path(@user) %></h2>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,30 +1,43 @@
-<%= render 'info', user: current_user %>
+<div class="container px-5 px-sm-0">
+  <div class="row">
+    <div class="col-md-3">
+      <h3 class="font-weight-bold">ユーザー情報</h3>
+      <%= render 'info', user: current_user %>
+    </div>
+    <div class="col-md-8 offset-md-1">
+      <table class="table table-hover table-inverse">
+        <thead>
+          <tr>
+            <th><%= link_to '投稿一覧', user_path %></th>
+            <th><%= link_to "お気に入り投稿一覧", like_user_path(@user) %></th>
+            <% @posts.each do |post| %>
+              <tr class="card mb-3" style="max-width: 540px;">
+                <td><%= link_to post_path(post.id) do %>
+                  <%= attachment_image_tag post, :image, :fill, 200, 150, format: 'jpeg', fallback: "no_image.jpg" %>
+                  <% end %>
+                </td>
 
-<h2><%= link_to '投稿一覧', user_path %></h2>
-<h2><%= link_to "お気に入り投稿一覧", like_user_path(@user) %></h2>
-<% @posts.each do |post| %>
-<div>
-  <p><%= link_to post_path(post.id) do %>
-    <%= attachment_image_tag post, :image, :fill, 200, 150, format: 'jpeg', fallback: "no_image.jpg" %>
-    <%= post.title %>
-    <% end %>
-  </p>
+                <td><%= post.title %></td>
 
-  <p><%= post.caption %></p>
+                <td><%= post.caption %></td>
 
-  <!-- post.spot.address -->
-  <!-- 投稿に関連づけられた所在地を表示 -->
+                <!-- post.spot.address -->
+                <!-- 投稿に関連づけられた所在地を表示 -->
 
-  <!-- post.tag.tag_name -->
-  <!-- 投稿に関連づけられたタグを表示 -->
+                <!-- post.tag.tag_name -->
+                <!-- 投稿に関連づけられたタグを表示 -->
 
-  <p>
-    <%= post.created_at.strftime('%Y年%-m月%-d日')%>
-    &nbsp|&nbsp
-    <%= link_to user_path(post.user) do %>
-    <%= post.user.name %>
-    <% end %>
-  </p>
+                <td><%= post.created_at.strftime('%Y年%-m月%-d日')%></td>
+                <td><%= link_to user_path(post.user) do %>
+                  <%= post.user.name %>
+                  <% end %>
+                </td>
+              </tr>
+            <% end %>
+          </tr>
+        </thead>
+      </table>
+      <%= paginate @posts %>
+    </div>
+  </div>
 </div>
-<% end %>
-<%= paginate @posts %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,42 +1,49 @@
 <div class="container px-5 px-sm-0">
   <div class="row">
-    <div class="col-md-3">
-      <h3 class="font-weight-bold">ユーザー情報</h3>
+    <div class="col-md-3 mt-3">
       <%= render 'info', user: current_user %>
     </div>
     <div class="col-md-8 offset-md-1">
-      <table class="table table-hover table-inverse">
-        <thead>
-          <tr>
-            <th><%= link_to '投稿一覧', user_path %></th>
-            <th><%= link_to "お気に入り投稿一覧", like_user_path(@user) %></th>
-            <% @posts.each do |post| %>
-              <tr class="card mb-3" style="max-width: 540px;">
-                <td><%= link_to post_path(post.id) do %>
-                  <%= attachment_image_tag post, :image, :fill, 200, 150, format: 'jpeg', fallback: "no_image.jpg" %>
-                  <% end %>
-                </td>
+      <div class="row border-bottom">
+        <div class="col-md  mt-3 text-center border-bottom">
+          <h4><%= link_to '投稿一覧', user_path %></h4>
+        </div>
+        <div class="col-md  mt-3 text-center">
+          <h4><%= link_to "お気に入り投稿一覧", like_user_path(@user) %></h4>
+        </div>
+      </div>
+      <% @posts.each do |post| %>
+      <div class="card mb-3 m-3">
+        <div class="row no-gutters">
+          <div class="col-lg-4 my-auto">
+            <div class="post-image">
+              <%= link_to post_path(post.id) do %>
+                <%= attachment_image_tag post, :image, width: "100%", format: "jpeg", fallback: "no_image.jpg" %>
+              <% end %>
+            </div>
+          </div>
+          <div class="col-lg-8">
+            <div class="card-body">
+              <h4 class="font-weight-bold"><%= post.title %></h4>
+              <p class="card-text"><%= post.caption.truncate(24) %></p>
+              <!-- post.spot.address -->
+              <!-- 投稿に関連づけられた所在地を表示 -->
 
-                <td><%= post.title %></td>
+              <!-- post.tag.tag_name -->
+              <!-- 投稿に関連づけられたタグを表示 -->
 
-                <td><%= post.caption %></td>
-
-                <!-- post.spot.address -->
-                <!-- 投稿に関連づけられた所在地を表示 -->
-
-                <!-- post.tag.tag_name -->
-                <!-- 投稿に関連づけられたタグを表示 -->
-
-                <td><%= post.created_at.strftime('%Y年%-m月%-d日')%></td>
-                <td><%= link_to user_path(post.user) do %>
-                  <%= post.user.name %>
-                  <% end %>
-                </td>
-              </tr>
-            <% end %>
-          </tr>
-        </thead>
-      </table>
+              <p>
+                <%= post.created_at.strftime('%Y年%-m月%-d日')%>
+                &nbsp|&nbsp
+                <%= link_to user_path(post.user) do %>
+                <%= post.user.name %>
+                <% end %>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <% end %>
       <%= paginate @posts %>
     </div>
   </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -6,39 +6,55 @@
     <div class="col-md-8 offset-md-1">
       <div class="row border-bottom">
         <div class="col-md  mt-3 text-center border-bottom">
-          <h4><%= link_to '投稿一覧', user_path %></h4>
+          <h4>投稿一覧</h4>
         </div>
         <div class="col-md  mt-3 text-center">
           <h4><%= link_to "お気に入り投稿一覧", like_user_path(@user) %></h4>
         </div>
       </div>
+
       <% @posts.each do |post| %>
-      <div class="card mb-3 m-3">
+      <div class="card mb-3 m-3 p-3">
         <div class="row no-gutters">
-          <div class="col-lg-4 my-auto">
+          <div class="col-md-4 my-auto">
             <div class="post-image">
               <%= link_to post_path(post.id) do %>
-                <%= attachment_image_tag post, :image, width: "100%", format: "jpeg", fallback: "no_image.jpg" %>
+                <%= attachment_image_tag post, :image, width: "100%", height:"auto", format: "jpeg", fallback: "no_image.jpg" %>
+
               <% end %>
             </div>
           </div>
-          <div class="col-lg-8">
-            <div class="card-body">
-              <h4 class="font-weight-bold"><%= post.title %></h4>
-              <p class="card-text"><%= post.caption.truncate(24) %></p>
-              <!-- post.spot.address -->
-              <!-- 投稿に関連づけられた所在地を表示 -->
-
-              <!-- post.tag.tag_name -->
-              <!-- 投稿に関連づけられたタグを表示 -->
-
-              <p>
-                <%= post.created_at.strftime('%Y年%-m月%-d日')%>
-                &nbsp|&nbsp
-                <%= link_to user_path(post.user) do %>
-                <%= post.user.name %>
-                <% end %>
-              </p>
+          <div class="col-md-8 my-auto">
+            <div class="card-body col-md">
+              <div class="row">
+                <div class="col-sm-12">
+                  <h4 class="card-title font-weight-bold">
+                    <%= link_to post_path(post.id) do %>
+                      <%= post.title %>
+                    <% end %>
+                  </h4>
+                </div>
+                <div class="col-sm-12">
+                  <p class="card-text"><%= post.caption.truncate(24) %></p>
+                </div>
+                <div class="col-sm-4">
+                  <p class="card-text"><!-- post.spot.address --></p>
+                  <!-- 投稿に関連づけられた所在地を表示 -->
+                </div>
+                <div class="col-sm-8">
+                  <p class="card-text"><!-- post.tag.tag_name --></p>
+                  <!-- 投稿に関連づけられたタグを表示 -->
+                </div>
+                <div class="col-sm-8">
+                  <p>
+                    <%= post.created_at.strftime('%Y年%-m月%-d日')%>
+                    &nbsp|&nbsp
+                    <%= link_to user_path(post.user) do %>
+                    <%= post.user.name %>
+                    <% end %>
+                  </p>
+                </div>
+              </div>
             </div>
           </div>
         </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -4,12 +4,12 @@
       <%= render 'info', user: current_user %>
     </div>
     <div class="col-md-8 offset-md-1">
-      <div class="row border-bottom">
-        <div class="col-md text-center">
+      <div class="row">
+        <div class="col-md-6 text-center">
           <h4 class="mt-3">投稿一覧</h4>
         </div>
-        <div class="col-md text-center">
-          <h4 class="mt-3"><%= link_to "お気に入り投稿一覧", like_user_path(@user) %></h4>
+        <div class="col-md-6 text-center">
+          <h4 class="mt-3"><%= link_to "お気に入り投稿一覧", like_user_path(@user), class: "link" %></h4>
         </div>
       </div>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,26 +1,25 @@
-<div class="container px-5 px-sm-0">
+<div class="container my-4">
   <div class="row">
-    <div class="col-md-3 mt-3">
+    <div class="col-md-3">
       <%= render 'info', user: current_user %>
     </div>
     <div class="col-md-8 offset-md-1">
       <div class="row border-bottom">
-        <div class="col-md  mt-3 text-center border-bottom">
-          <h4>投稿一覧</h4>
+        <div class="col-md text-center">
+          <h4 class="mt-3">投稿一覧</h4>
         </div>
-        <div class="col-md  mt-3 text-center">
-          <h4><%= link_to "お気に入り投稿一覧", like_user_path(@user) %></h4>
+        <div class="col-md text-center">
+          <h4 class="mt-3"><%= link_to "お気に入り投稿一覧", like_user_path(@user) %></h4>
         </div>
       </div>
 
       <% @posts.each do |post| %>
-      <div class="card mb-3 m-3 p-3">
+      <div class="card my-3 p-3">
         <div class="row no-gutters">
           <div class="col-md-4 my-auto">
             <div class="post-image">
               <%= link_to post_path(post.id) do %>
                 <%= attachment_image_tag post, :image, width: "100%", height:"auto", format: "jpeg", fallback: "no_image.jpg" %>
-
               <% end %>
             </div>
           </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -9,6 +9,8 @@ ja:
       user:
         name: ユーザー名
         email: メールアドレス
+        introduction: 自己紹介
+        profile_image: プロフィール画像
         password: パスワード
         password_confirmation: 確認用パスワード
       post:


### PR DESCRIPTION
* アプリ内のフォントを変更・top画面のテキストを修正
* ユーザー情報編集画面のレイアウトを修正
* 新規登録画面 変更を保存ボタンのclass名を変更
* ユーザー情報のレイアウトを編集/部分テンプレート化
* ユーザーの投稿一覧・お気に入り投稿一覧にカードを適用
* ユーザーの投稿一覧・お気に入り投稿一覧 リンクの表示を修正