### PR TITLE
Post tag/#50

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -81,19 +81,19 @@
  }
 
  .fa-link:hover {
-   text-decoration:none;
+   text-decoration: none;
  }
 
  .fa-link:active {
-   text-decoration:none;
+   text-decoration: none;
  }
 
  .show-link {
-   color:#000;
+   color: #000;
  }
 
  .show-link:hover {
-   color:#000;
+   color: #000;
  }
 
  .img {
@@ -102,7 +102,7 @@
    transition: .3s ease-in-out;
  }
 
-  .img:hover {
+ .img:hover {
    opacity: .5;
  }
 
@@ -125,4 +125,16 @@
  /*ホバー時のデザイン*/
  .pagination>li>a:hover {
    border-radius: 15px;    /*角を丸くする*/
+ }
+
+ .tag_link {
+   color:#000;
+ }
+
+ .tag_link:hover {
+   color:#000;
+ }
+
+ .fa-hashtag {
+
  }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -36,19 +36,19 @@
  }
 
  .link:hover {
-   color:#000;
+   color: #000;
  }
 
  .link:active {
-   color:#999;
+   color: #999;
  }
 
  .title-link {
-   color:#000;
+   color: #000;
  }
 
  .title-link:hover {
-   color:#000;
+   color: #000;
  }
 
  .vertical-middle{
@@ -57,7 +57,7 @@
  }
 
  .user-info {
-   color:#C0C0C0;
+   color: #C0C0C0;
  }
 
  .like-btn {
@@ -128,13 +128,13 @@
  }
 
  .tag_link {
-   color:#000;
+   color: #000;
  }
 
  .tag_link:hover {
-   color:#000;
+   color: #000;
  }
 
  .fa-hashtag {
-
+   color: #C0C0C0;
  }

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -47,11 +47,14 @@ class PostsController < ApplicationController
 
   def edit
     @post = Post.find(params[:id])
+    @tag_list = @post.tags.pluck(:tag_name).join(',')
   end
 
   def update
     @post = Post.find(params[:id])
+    tag_list = params[:post][:tag_name].split(',')
     if @post.update(post_params)
+      @post.save_tag(tag_list)
       redirect_to post_path(@post)
     else
       render :edit

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -11,7 +11,11 @@ class PostsController < ApplicationController
   def create
     @post = Post.new(post_params)
     @post.user_id = current_user.id
+    tag_list = params[:post][:tag_name].split(nil)
+    # formから@postオブジェクトを参照してタグの名前も一緒に送信するのでこの形で取得する .split(nil)で送信されてきた値を、スペースで区切って配列化
     if @post.save
+      @post.save_tag(tag_list)
+      # 取得したタグの配列をデータベースに保存する処理
       redirect_to post_path(@post)
     else
       render :new

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -65,7 +65,9 @@ class PostsController < ApplicationController
   end
 
   def search
-
+    @tag_list = Tag.all
+    @tag = Tag.find(params[:tag_id])
+    @posts = @tag.posts.all
   end
 
   private

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -12,7 +12,7 @@ class PostsController < ApplicationController
     @post = Post.new(post_params)
     @post.user_id = current_user.id
     tag_list = params[:post][:tag_name].split(nil)
-    # formから@postオブジェクトを参照してタグの名前も一緒に送信するのでこの形で取得する .split(nil)で送信されてきた値を、スペースで区切って配列化
+    # formから@postオブジェクトを参照してタグの名前も一緒に送信するのでこの形で取得する .split(nil)で送信されてきた値をスペースで区切って配列化
     if @post.save
       @post.save_tag(tag_list)
       # 取得したタグの配列をデータベースに保存する処理

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -65,6 +65,7 @@ class PostsController < ApplicationController
   end
 
   def search
+
   end
 
   private

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -25,6 +25,7 @@ class PostsController < ApplicationController
   def index
     @posts = Post.page(params[:page]).reverse_order
     # 1ページ分の決められた数のデータだけを、新しい順に取得するように変更
+    @tag_list = Tag.all
   end
 
   def show
@@ -37,6 +38,10 @@ class PostsController < ApplicationController
       # 定義した@latと@lngの変数をJavaScriptでも扱えるように、それぞれgon.latとgon.lngに代入
       gon.lat = @lat
       gon.lng = @lng
+    end
+    # 投稿内容のタグの値がnilでなければ、投稿詳細画面にタグを表示する
+    if @post.tags != nil
+      @post_tags = @post.tags
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,6 +6,7 @@ class UsersController < ApplicationController
     @user = User.find(params[:id])
     @posts = @user.posts.page(params[:page]).reverse_order
     # ユーザーに関連づけられた投稿のみ、@postsに渡す
+    @tag_list = Tag.all
   end
 
   def edit
@@ -26,6 +27,7 @@ class UsersController < ApplicationController
     likes = Like.where(user_id: @user.id).pluck(:post_id)
     # whereメソッドでlikesテーブルから自分のidが登録されているレコードを取得し、pluckメソッドで取得したレコードからpost_idを配列の形で取得
     @likes = Post.find(likes)
+    @tag_list = Tag.all
   end
 
   private

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -20,19 +20,19 @@ class Post < ApplicationRecord
 
   def save_tag(sent_tags)
     # 現在存在するタグ・古いタグ・新しいタグをそれぞれ取得
-    current_tags = salf.tags.pluck(:tag_name) unless self.tags.nil?
+    current_tags = self.tags.pluck(:tag_name) unless self.tags.nil?
     old_tags = current_tags - sent_tags
     new_tags = sent_tags - current_tags
 
     # 古いタグの削除
     old_tags.each do |old|
-      self.post_tags.delete PostTag.find_by(tag_name: old)
+      self.tags.delete Tag.find_by(tag_name: old)
     end
 
     # 新しいタグの保存
     new_tags.each do |new|
-      new_post_tag = PostTag.find_or_create_by(tag_name: new)
-      self.post_tags << new_post_tag
+      post_tag = Tag.find_or_create_by(tag_name: new)
+      self.tags << post_tag
     end
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -17,4 +17,22 @@ class Post < ApplicationRecord
   def liked_by(user)
     Like.find_by(user_id: user.id, post_id: id)
   end
+
+  def save_tag(sent_tags)
+    # 現在存在するタグ・古いタグ・新しいタグをそれぞれ取得
+    current_tags = salf.tags.pluck(:tag_name) unless self.tags.nil?
+    old_tags = current_tags - sent_tags
+    new_tags = sent_tags - current_tags
+
+    # 古いタグの削除
+    old_tags.each do |old|
+      self.post_tags.delete PostTag.find_by(tag_name: old)
+    end
+
+    # 新しいタグの保存
+    new_tags.each do |new|
+      new_post_tag = PostTag.find_or_create_by(tag_name: new)
+      self.post_tags << new_post_tag
+    end
+  end
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,4 +1,5 @@
 class Tag < ApplicationRecord
   has_many :tag_maps, dependent: :destroy, foreign_key: 'tag_id'
   has_many :posts, through: :tag_maps
+  validates :tag_name, uniqueness: true
 end

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -14,6 +14,13 @@
 </div>
 
 <div class="form-group">
+  <%= "スペースを入力することで複数のタグを付けることができます。" %>
+  <%= "例：お土産 グルメ 穴場スポット" %>
+  <%= f.label :tag_name, class: "form-label" %>
+  <%= f.text_area :tag_name, placeholder: "タグの名前を入力", class: "form-control" %>
+</div>
+
+<div class="form-group">
   <%= f.fields_for :spot do |s| %>
     <%= s.label :address, "場所(Google Mapで検索)", class: "spot_title" %>
     <%= s.text_field :address, placeholder: "スポットを入力", id: "address", class: "spot_text" %>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -13,12 +13,22 @@
   <%= f.text_area :caption, placeholder: "説明文を入力してください", class: "form-control" %>
 </div>
 
-<div class="form-group">
-  <%= f.label :tag_name, class: "form-label" %><br>
-  <%= "カンマ（,）で区切ることで複数のタグを付けることができます。" %><br>
-  <%= "例：お土産 グルメ 穴場スポット" %>
-  <%= f.text_field :tag_name, placeholder: "付けたいタグの名前を入力", class: "form-control" %>
-</div>
+<% if local_assigns[:edit_flag].present? %>
+<!-- partialの指定したローカル変数に値が入っているか否かを判別し切り分ける -->
+  <div class="form-group">
+    <%= f.label :tag_name, class: "form-label" %><br>
+    <%= "カンマ（,）で区切ることで複数のタグを付けることができます。" %><br>
+    <%= "例：お土産,グルメ,穴場スポット" %>
+    <%= f.text_field :tag_name, value: @tag_list, placeholder: "付けたいタグの名前を入力", class: "form-control" %>
+  </div>
+<% else %>
+  <div class="form-group">
+    <%= f.label :tag_name, class: "form-label" %><br>
+    <%= "カンマ（,）で区切ることで複数のタグを付けることができます。" %><br>
+    <%= "例：お土産,グルメ,穴場スポット" %>
+    <%= f.text_field :tag_name, placeholder: "付けたいタグの名前を入力", class: "form-control" %>
+  </div>
+<% end %>
 
 <div class="form-group">
   <%= f.fields_for :spot do |s| %>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -14,10 +14,10 @@
 </div>
 
 <div class="form-group">
-  <%= "スペースを入力することで複数のタグを付けることができます。" %>
+  <%= f.label :tag_name, class: "form-label" %><br>
+  <%= "スペースを入力することで複数のタグを付けることができます。" %><br>
   <%= "例：お土産 グルメ 穴場スポット" %>
-  <%= f.label :tag_name, class: "form-label" %>
-  <%= f.text_area :tag_name, placeholder: "タグの名前を入力", class: "form-control" %>
+  <%= f.text_field :tag_name, placeholder: "付けたいタグの名前を入力", class: "form-control" %>
 </div>
 
 <div class="form-group">

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -15,7 +15,7 @@
 
 <div class="form-group">
   <%= f.label :tag_name, class: "form-label" %><br>
-  <%= "スペースを入力することで複数のタグを付けることができます。" %><br>
+  <%= "カンマ（,）で区切ることで複数のタグを付けることができます。" %><br>
   <%= "例：お土産 グルメ 穴場スポット" %>
   <%= f.text_field :tag_name, placeholder: "付けたいタグの名前を入力", class: "form-control" %>
 </div>

--- a/app/views/posts/_tag_list.html.erb
+++ b/app/views/posts/_tag_list.html.erb
@@ -3,10 +3,10 @@
     <h4 class="text-center font_space">タグ一覧</h4>
   </div>
   <div class="col-md-12 m-1">
-    <% tag_list.each do |list| %>
+    <% @tag_list.each do |list| %>
       <span>
         <%= link_to list.tag_name, tag_posts_path(tag_id: list.id) %>
-        <%= "(#{list.posts.count})"%>
+        <%= list.posts.count %>
       </span>
     <% end %>
   </div>

--- a/app/views/posts/_tag_list.html.erb
+++ b/app/views/posts/_tag_list.html.erb
@@ -2,12 +2,14 @@
   <div class="col-md-12 mt-3">
     <h4 class="text-center font_space">タグ一覧</h4>
   </div>
-  <div class="col-md-12 m-1">
-    <% tag_list.each do |list| %>
-      <span>
-        <%= link_to list.tag_name, tag_posts_path(tag_id: list.id) %>
-        <%= "(#{list.posts.count})" %>
-      </span>
-    <% end %>
+  <div class="col-md-12">
+    <div class="row">
+      <% tag_list.each do |list| %>
+        <div class="col-sm-6 col-xs-6">
+          <i class="fas fa-hashtag"></i>
+          <%= link_to list.tag_name, tag_posts_path(tag_id: list.id), class: "tag_link" %>
+        </div>
+      <% end %>
+    </div>
   </div>
 </div>

--- a/app/views/posts/_tag_list.html.erb
+++ b/app/views/posts/_tag_list.html.erb
@@ -3,10 +3,10 @@
     <h4 class="text-center font_space">タグ一覧</h4>
   </div>
   <div class="col-md-12 m-1">
-    <% @tag_list.each do |list| %>
+    <% tag_list.each do |list| %>
       <span>
         <%= link_to list.tag_name, tag_posts_path(tag_id: list.id) %>
-        <%= list.posts.count %>
+        <%= "(#{list.posts.count})" %>
       </span>
     <% end %>
   </div>

--- a/app/views/posts/_tag_list.html.erb
+++ b/app/views/posts/_tag_list.html.erb
@@ -1,0 +1,13 @@
+<div class="row">
+  <div class="col-md-12 mt-3">
+    <h4 class="text-center font_space">タグ一覧</h4>
+  </div>
+  <div class="col-md-12 m-1">
+    <% tag_list.each do |list| %>
+      <span>
+        <%= link_to list.tag_name, tag_posts_path(tag_id: list.id) %>
+        <%= "(#{list.posts.count})"%>
+      </span>
+    <% end %>
+  </div>
+</div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -5,7 +5,7 @@
         <%= render 'users/info', user: current_user %>
       </div>
       <div>
-        <%= render 'tag_list', post: @post %>
+        <%= render 'tag_list', tag_list: @tag_list %>
       </div>
     </div>
     <div class="col-md-8 offset-md-1">

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -4,9 +4,8 @@
       <div>
         <%= render 'users/info', user: current_user %>
       </div>
-      <div class="text-center">
-        <h4 class="mt-3 font_space">タグ一覧</h4>
-        <!--タグ付け機能追加後、部分テンプレートを用いてタグ一覧を表示する-->
+      <div>
+        <%= render 'tag_list', post: @post %>
       </div>
     </div>
     <div class="col-md-8 offset-md-1">

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -36,16 +36,8 @@
                   <div class="col-sm-12">
                     <p class="card-text"><%= post.caption.truncate(24) %></p>
                   </div>
-                  <div class="col-sm-4">
-                    <p class="card-text"><!-- post.spot.address --></p>
-                    <!-- 投稿に関連づけられた所在地を表示 -->
-                  </div>
-                  <div class="col-sm-8">
-                    <p class="card-text"><!-- post.tag.tag_name --></p>
-                    <!-- 投稿に関連づけられたタグを表示 -->
-                  </div>
                   <div class="col-sm-12">
-                    <p>
+                    <p class="card-text">
                       <%= post.created_at.strftime('%Y年%-m月%-d日')%>
                       &nbsp|&nbsp
                       <%= link_to user_path(post.user), class: "link" do %>

--- a/app/views/posts/search.html.erb
+++ b/app/views/posts/search.html.erb
@@ -9,9 +9,12 @@
       </div>
     </div>
     <div class="col-md-8 offset-md-1">
-      <div class="row">
-        <div class="col-md text-center">
-          <h4 class="mt-3 font_space"><%= "タグが ─ " %><%= "#{@tag.tag_name}" %><%= " ─ の投稿一覧" %></h4>
+      <div class="row mt-3">
+        <div class="col-md-2">
+          <%= link_to " 戻る", :back, class: "btn btn-outline-dark btn-sm" %>
+        </div>
+        <div class="col-md-10 text-center">
+          <h4 class="font_space"><%= "タグが ─ " %><%= "#{@tag.tag_name}" %><%= " ─ の投稿一覧" %></h4>
         </div>
       </div>
       <% if @posts.empty? %>
@@ -44,7 +47,7 @@
                         <p class="card-text"><%= post.caption.truncate(24) %></p>
                       </div>
                       <div class="col-sm-12">
-                        <p>
+                        <p class="card-text">
                           <%= post.created_at.strftime('%Y年%-m月%-d日')%>
                           &nbsp|&nbsp
                           <%= link_to user_path(post.user), class: "link" do %>

--- a/app/views/posts/search.html.erb
+++ b/app/views/posts/search.html.erb
@@ -1,2 +1,70 @@
-<h1>Posts#search</h1>
-<p>Find me in app/views/posts/search.html.erb</p>
+<div class="container my-4">
+  <div class="row">
+    <div class="col-md-3">
+      <div>
+        <%= render 'users/info', user: current_user %>
+      </div>
+      <div>
+        <%= render 'tag_list', tag_list: @tag_list %>
+      </div>
+    </div>
+    <div class="col-md-8 offset-md-1">
+      <div class="row">
+        <div class="col-md text-center">
+          <h4 class="mt-3 font_space"><%= "タグが ─ " %><%= "#{@tag.tag_name}" %><%= " ─ の投稿一覧" %></h4>
+        </div>
+      </div>
+      <% if @posts.empty? %>
+        <div class="card my-5 p-3">
+          <div class="text-center">
+            まだ投稿されていません
+          </div>
+        </div>
+      <% else %>
+        <% @posts.each do |post| %>
+          <div class="card my-3 p-3">
+            <div class="row no-gutters">
+              <div class="col-md-4 my-auto">
+                  <%= link_to post_path(post.id) do %>
+                  <%= attachment_image_tag post, :image, width: "100%", height:"auto", format: "jpeg", fallback: "no_image.jpg", class: "img" %>
+                  <% end %>
+              </div>
+              <div class="col-md-8 my-auto">
+                <div class="card-body col-md">
+                  <div class="row">
+                    <div class="col-sm-12">
+                      <h4 class="card-title font-weight-bold">
+                        <%= link_to post_path(post.id), class: "title-link" do %>
+                          <%= post.title %>
+                        <% end %>
+                      </h4>
+                    </div>
+                    <div class="user-info">
+                      <div class="col-sm-12">
+                        <p class="card-text"><%= post.caption.truncate(24) %></p>
+                      </div>
+                      <div class="col-sm-12">
+                        <p>
+                          <%= post.created_at.strftime('%Y年%-m月%-d日')%>
+                          &nbsp|&nbsp
+                          <%= link_to user_path(post.user), class: "link" do %>
+                          <%= post.user.name %>
+                          <% end %>
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        <% end %>
+      <% end %>
+      <div class="row">
+        <div class="mx-auto">
+          <!--<p class="d-flex align-items-center">< %= paginate @posts %></p>-->
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -24,8 +24,13 @@
   <%= attachment_image_tag @post, :image, width: "100%", height:"auto", format: "jpeg", fallback: "no_image.jpg" %>
   <div class="card-body">
     <p class="card-text"><%= @post.caption %></p>
-      <!-- post.tag.tag_name -->
-      <!-- 投稿に関連づけられたタグを表示 -->
+    <% if @post.tags != nil %>
+      <%= @post_tags.each do |tag| %>
+      <span>
+        <%= link_to tag.tag_name, tag_posts_path(tag_id: tag.id)%>
+        <%= "(#{tag.posts.count})" %>
+      </span>
+    <% end %>
 
     <% if @post.spot != nil %>
       <p class="card-text"><%= @post.spot.address %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -26,10 +26,11 @@
     <p class="card-text"><%= @post.caption %></p>
     <% if @post.tags != nil %>
       <%= @post_tags.each do |tag| %>
-      <span>
-        <%= link_to tag.tag_name, tag_posts_path(tag_id: tag.id)%>
-        <%= "(#{tag.posts.count})" %>
-      </span>
+        <p class="card-text">
+          <%= link_to tag.tag_name, tag_posts_path(tag_id: tag.id)%>
+          <%= "(#{tag.posts.count})" %>
+         </p>
+      <% end %>
     <% end %>
 
     <% if @post.spot != nil %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -25,6 +25,7 @@
   <div class="card-body">
     <p class="card-text"><%= @post.caption %></p>
     <% if @post.tags != nil %>
+      <%= "タグ: " %>
       <% @post_tags.each do |tag| %>
         <span class="card-text">
           <%= link_to tag.tag_name, tag_posts_path(tag_id: tag.id) %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -25,11 +25,10 @@
   <div class="card-body">
     <p class="card-text"><%= @post.caption %></p>
     <% if @post.tags != nil %>
-      <%= @post_tags.each do |tag| %>
-        <p class="card-text">
-          <%= link_to tag.tag_name, tag_posts_path(tag_id: tag.id)%>
-          <%= "(#{tag.posts.count})" %>
-         </p>
+      <% @post_tags.each do |tag| %>
+        <span class="card-text">
+          <%= link_to tag.tag_name, tag_posts_path(tag_id: tag.id) %>
+        </span>
       <% end %>
     <% end %>
 

--- a/app/views/users/like.html.erb
+++ b/app/views/users/like.html.erb
@@ -4,9 +4,8 @@
       <div>
         <%= render 'info', user: @user %>
       </div>
-      <div class="text-center">
-        <h4 class="mt-3 font_space">タグ一覧</h4>
-        <!--タグ付け機能追加後、部分テンプレートを用いてタグ一覧を表示する-->
+      <div>
+        <%= render 'posts/tag_list', tag_list: @tag_list %>
       </div>
     </div>
     <div class="col-md-8 offset-md-1">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -4,9 +4,8 @@
       <div>
         <%= render 'info', user: @user %>
       </div>
-      <div class="text-center">
-        <h4 class="mt-3 font_space">タグ一覧</h4>
-        <!--タグ付け機能追加後、部分テンプレートを用いてタグ一覧を表示する-->
+      <div>
+        <%= render 'posts/tag_list', tag_list: @tag_list %>
       </div>
     </div>
     <div class="col-md-8 offset-md-1">
@@ -49,16 +48,8 @@
                     <div class="col-sm-12">
                       <p class="card-text"><%= post.caption.truncate(24) %></p>
                     </div>
-                    <div class="col-sm-4">
-                      <p class="card-text"><!-- post.spot.address --></p>
-                      <!-- 投稿に関連づけられた所在地を表示 -->
-                    </div>
-                    <div class="col-sm-8">
-                      <p class="card-text"><!-- post.tag.tag_name --></p>
-                      <!-- 投稿に関連づけられたタグを表示 -->
-                    </div>
                     <div class="col-sm-12">
-                      <p>
+                      <p class="card-text">
                         <%= post.created_at.strftime('%Y年%-m月%-d日')%>
                         &nbsp|&nbsp
                         <%= link_to user_path(post.user), class: "link" do %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -12,6 +12,7 @@ ja:
       post: 投稿
       like: お気に入り
       tag_map: タグ付け
+      tag: タグ
     attributes:
       user:
         name: ユーザー名
@@ -24,6 +25,7 @@ ja:
         image: 画像
         title: タイトル
         caption: 説明文
+        tag_name: タグ
       like:
         user_id: ユーザーID
       tag_map:


### PR DESCRIPTION
* postsコントローラのcreateアクションにタグを作成するコードを追記
* postsコントローラのindexアクション・showアクションにタグを取得するコードを追記 
* Postモデルに、save_tagインスタンスメソッドを定義
* タグ一覧のビューを作成/投稿一覧のビューを修正
* 投稿詳細ページにタグを表示するコードを追記
* postsコントローラにsearchアクションを作成する
* タグで投稿を絞り込み表示する機能を実装
* ユーザー投稿一覧・お気に入り画面にタグ一覧を表示
* Tagモデルにタグの名前が重複しないよう設定/ハッシュタグアイコンの色を修正
* 投稿編集時にタグの情報がフォームに入るよう追記・タグカラムを日本語化