### PR TITLE
[add] スポットが空欄のまま投稿できないようにバリデーションを追加 #81

### DIFF
--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -1,6 +1,8 @@
 class Spot < ApplicationRecord
   belongs_to :post
 
+  validates :address, presence: true
+
   geocoded_by :address
   after_validation :geocode
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -26,6 +26,8 @@ ja:
         title: タイトル
         caption: 説明文
         tag_name: タグ
+      spot:
+        address: スポット
       like:
         user_id: ユーザーID
       tag_map:


### PR DESCRIPTION
* スポットが空欄のまま投稿できないようにバリデーションを追加
マイグレーションファイルにnull: falseを指定していたが、モデルにバリデーションをかけるのを失念していた。
* addressカラムを日本語化