### PR TITLE
[fix] postsコントローラのcreateアクション タグの取得方法を修正 #82

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -11,8 +11,8 @@ class PostsController < ApplicationController
   def create
     @post = Post.new(post_params)
     @post.user_id = current_user.id
-    tag_list = params[:post][:tag_name].split(nil)
-    # formから@postオブジェクトを参照してタグの名前も一緒に送信するのでこの形で取得する .split(nil)で送信されてきた値をスペースで区切って配列化
+    tag_list = params[:post][:tag_name].split(',')
+    # formから@postオブジェクトを参照してタグの名前も一緒に送信するのでこの形で取得する .split(',')で送信されてきた値をスペースで区切って配列化
     if @post.save
       @post.save_tag(tag_list)
       # 取得したタグの配列をデータベースに保存する処理


### PR DESCRIPTION
* 複数のタグを生成する方法を、スペースで区切る方法からカンマで区切る方法に変更したが、createアクションのみ変更されていなかった。
修正し、カンマで区切って複数のタグが生成されることを確認。