### PR TITLE
[fix] scriptタグの記述する位置と読み込まれるタイミングを変更・turbolinksを部分的に無効化 #80

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -43,10 +43,14 @@
               <a class="icon fas fa-link nav-link active" href="/#about">「じもたび」とは？</a>
             </li>
             <li class="nav-item">
-              <%= link_to ' 新規登録', new_user_registration_path, class: 'fas fa-user-plus nav-link active' %>
+              <div data-turbolinks="false">
+                <%= link_to ' 新規登録', new_user_registration_path, class: 'fas fa-user-plus nav-link active' %>
+              </div>
             </li>
             <li class="nav-item">
-              <%= link_to ' ログイン', new_user_session_path, class: 'fas fa-sign-in-alt nav-link active' %>
+              <div data-turbolinks="false">
+                <%= link_to ' ログイン', new_user_session_path, class: 'fas fa-sign-in-alt nav-link active' %>
+              </div>
             </li>
           </ul>
         <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,16 +9,14 @@
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
     <%= Gon::Base.render_data %>
     <link href="https://fonts.googleapis.com/css2?family=Sawarabi+Mincho&display=swap" rel="stylesheet">
+    <script src="https://maps.googleapis.com/maps/api/js?key=<%=ENV["GOOGLE_MAP_KEY"]%>&callback=initMap" defer></script>
+    <script src="//cdn.rawgit.com/mahnunchik/markerclustererplus/master/dist/markerclusterer.min.js" defer></script>
+    <script src="//cdn.rawgit.com/printercu/google-maps-utility-library-v3-read-only/master/infobox/src/infobox_packed.js" defer></script>
   </head>
 
   <body>
     <%= render 'layouts/header' %>
       <%= yield %>
     <%= render 'layouts/footer' %>
-    <!--<#% if current_page?("/posts/#{params[:id]}") || current_page?(controller: 'posts', action: 'new') || current_page?("/posts/#{params[:id]}/edit") %>-->
-      <script src="https://maps.googleapis.com/maps/api/js?key=<%=ENV["GOOGLE_MAP_KEY"]%>&callback=initMap"></script>
-      <script src="//cdn.rawgit.com/mahnunchik/markerclustererplus/master/dist/markerclusterer.min.js"></script>
-      <script src="//cdn.rawgit.com/printercu/google-maps-utility-library-v3-read-only/master/infobox/src/infobox_packed.js"></script>
-    <!--<#% end %>-->
   </body>
 </html>


### PR DESCRIPTION
* GoogleMapを表示するために必要なscriptタグをheadタグの中に移動
* scriptタグにdefer 属性を追加し、HTML パース完了後、DOMContentLoaded イベントの直前にJS ファイルを実行するよう設定
* ヘッダーのログイン・新規登録リンクのturbo linksを無効化