### PR TITLE
Fix/#80 js error

### DIFF
--- a/app/assets/javascripts/googlemap.js
+++ b/app/assets/javascripts/googlemap.js
@@ -11,15 +11,17 @@ function initMap(){ //コールバック関数
       zoom: 15, //拡大率（1〜21まで設定可能）
     });
   }else if(document.getElementById('show_map')){ //'map'というidが無かった場合
-    map = new google.maps.Map(document.getElementById('show_map'), { //'show_map'というidを取得してマップを表示
-      /*global gon*/
-      center: {lat: gon.lat, lng: gon.lng}, //controllerで定義した変数を緯度・経度の値とする（値はDBに入っている）
-      zoom: 15, //拡大率（1〜21まで設定可能）
-    });
-    marker = new google.maps.Marker({ //GoogleMapにマーカーを落とす
-      position:  {lat: gon.lat, lng: gon.lng}, //マーカーを落とす位置を決める（値はDBに入っている）
-      map: map //マーカーを落とすマップを指定
-    });
+    if(gon.lat && gon.lng){ //経度・緯度がDBに入っている場合
+      map = new google.maps.Map(document.getElementById('show_map'), { //'show_map'というidを取得してマップを表示
+        /*global gon*/
+        center: {lat: gon.lat, lng: gon.lng}, //controllerで定義した変数を緯度・経度の値とする（値はDBに入っている）
+        zoom: 15, //拡大率（1〜21まで設定可能）
+      });
+      marker = new google.maps.Marker({ //GoogleMapにマーカーを落とす
+        position:  {lat: gon.lat, lng: gon.lng}, //マーカーを落とす位置を決める（値はDBに入っている）
+        map: map //マーカーを落とすマップを指定
+      });
+    }
   }
 }
 

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -5,4 +5,14 @@ class Spot < ApplicationRecord
 
   geocoded_by :address
   after_validation :geocode
+
+  before_save :print_address
+  # バリデーションに成功し、実際にオブジェクトが保存される直前で実行
+
+  def print_address
+    pp self.address
+    pp self.latitude
+    pp self.longitude
+  end
+  # print_addressが実行された時、インスタンス変数のaddress・latitude・longitudeを参照
 end

--- a/db/migrate/20210621070352_change_column_to_allow_null.rb
+++ b/db/migrate/20210621070352_change_column_to_allow_null.rb
@@ -1,13 +1,13 @@
 class ChangeColumnToAllowNull < ActiveRecord::Migration[5.2]
   def up
-    change_column :spots, :address,:string, null: true
-    change_column :spots, :latitude,:float, null: true
-    change_column :spots, :longitude,:float, null: true
-  end
-
-  def down
     change_column :spots, :address,:string, null: false
     change_column :spots, :latitude,:float, null: false
     change_column :spots, :longitude,:float, null: false
+  end
+
+  def down
+    change_column :spots, :address,:string
+    change_column :spots, :latitude,:float
+    change_column :spots, :longitude,:float
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -32,9 +32,9 @@ ActiveRecord::Schema.define(version: 2021_06_21_070352) do
   end
 
   create_table "spots", force: :cascade do |t|
-    t.string "address"
-    t.float "latitude"
-    t.float "longitude"
+    t.string "address", null: false
+    t.float "latitude", null: false
+    t.float "longitude", null: false
     t.integer "post_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
緯度・経度が取得できていなかった。
原因は（gmaps4railsのAPI設定と同じように）「HTTP リファラー」で制限をかけていたためだった。
アプリケーションの制限を「なし」に変更。

インスタンス変数のaddress・latitude・longitudeを参照するため。、spotモデルに以下の記述を追記
```app/models/spot.rb
  before_save :print_address  
  # バリデーションに成功し、実際にオブジェクトが保存される直前で実行 

  def print_address   
    pp self.address    
    pp self.latitude   
    pp self.longitude  
  end 
  # print_addressが実行された時、インスタンス変数のaddress・latitude・longitudeを参照
```

再度、spotテーブルのカラムにNN制約をかける