### PR TITLE
[add] Better Errorsをcloud9で使えるように設定 #111

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -67,4 +67,6 @@ Rails.application.configure do
     Bullet.rails_logger = true # Railsのログに結果を出力
     Bullet.add_footer = true # ページの左下に結果を表示
   end
+
+  BetterErrors::Middleware.allow_ip! "0.0.0.0/0"
 end


### PR DESCRIPTION
config/environments/development.rbに追記
```config/environments/development.rb
Rails.application.configure do

  BetterErrors::Middleware.allow_ip! "0.0.0.0/0" # 追記
end
```