### PR TITLE
[fix] ログイン後の遷移先をマイページに変更 #136

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,7 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   def after_sign_in_path_for(resource)
-    posts_path(resource)
+    user_path(current_user.id)
   end
 
   def after_sign_out_path_for(resource)


### PR DESCRIPTION
ログイン後の遷移先をマイページに変更
app/controllers/application_controller.rb 
```app/controllers/application_controller.rb 
  def after_sign_in_path_for(resource)
    posts_path(resource) # 修正前
    user_path(current_user.id) # 修正後
  end
```