### PR TITLE
[fix] 投稿詳細画面のユーザー名をクリックするとユーザーの詳細画面へ遷移するように修正 #147

### DIFF
--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -7,7 +7,7 @@
           <%= attachment_image_tag @post.user, :profile_image, :fill, 50, 50, format: 'jpeg', fallback: "no_image.jpg", class: "rounded-circle" %>
         </p>
         <p class="vertical-middle">
-          <%= link_to post_path(@post.id), class: "show-link" do %>
+          <%= link_to user_path(@post.user), class: "show-link" do %>
             <%= @post.user.name %>
            <% end %>
         </p>


### PR DESCRIPTION
* 誤った遷移先を指定していたので修正
posts/show.html.erb
```posts/show.html.erb
<%= link_to post_path(@post.id), class: "show-link" do %> # 修正前
<%= link_to user_path(@post.user), class: "show-link" do %> # 修正後
```