### PR TITLE
[fix] 新規登録画面で使用していたautofocusを1つ削除 #152

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -11,7 +11,7 @@
 
     <div class="form-group">
       <%= f.label :email, class: "form-label" %><br>
-      <%= f.email_field :email, autofocus: true,  placeholder: "example@example.com", class: "form-control" %>
+      <%= f.email_field :email, placeholder: "example@example.com", class: "form-control" %>
     </div>
 
     <div class="form-group">


### PR DESCRIPTION
新規登録画面で使用していたautofocusを1つ削除
```app/views/devise/registrations/new.html.erb 
    <div class="form-group">
      <%= f.label :email, class: "form-label" %><br>
      <%= f.email_field :email, autofocus: true,  placeholder: "example@example.com", class: "form-control" %> # 修正前
      <%= f.email_field :email, placeholder: "example@example.com", class: "form-control" %> # 修正後
    </div>
```