### PR TITLE
[fix] メールアドレスを入力するフォームのオートコンプリートを無効化 #156

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -11,7 +11,7 @@
 
     <div class="form-group">
       <%= f.label :email, class: "form-label" %><br>
-      <%= f.email_field :email, placeholder: "example@example.com", class: "form-control" %>
+      <%= f.email_field :email, placeholder: "example@example.com", autocomplete: 'off', class: "form-control" %>
     </div>
 
     <div class="form-group">

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -5,7 +5,7 @@
 
     <div class="form-group">
       <%= f.label :email, class: "form-label" %>
-      <%= f.email_field :email, autofocus: true,  placeholder: "example@example.com", class: "form-control" %>
+      <%= f.email_field :email, autofocus: true,  placeholder: "example@example.com", autocomplete: 'off', class: "form-control" %>
     </div>
 
     <div class="form-group">


### PR DESCRIPTION
オートコンプリートを無効にしたい箇所にautocomplete: 'off'を追記
* 新規登録フォーム
* ログインフォーム