### PR TITLE
[fix] ゲストログインをした際の遷移先を変更 #159

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -3,6 +3,6 @@ class Users::SessionsController < Devise::SessionsController
   def guest_sign_in
     user = User.guest
     sign_in user
-    redirect_to posts_path
+    redirect_to user_path(current_user.id)
   end
 end


### PR DESCRIPTION
投稿一覧画面（posts_path）からユーザー詳細画面（user_path）に修正